### PR TITLE
Fix single file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 2.0.1 - Unreleased
+### 2.0.1 (2019-May-27)
+
+Fixed single file upload when at subdirectory.
 
 ### 2.0.0 (2019-May-19)
 

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishArtifactExecutor.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishArtifactExecutor.java
@@ -83,7 +83,7 @@ public class PublishArtifactExecutor implements RequestExecutor {
             }
             else if(matchingFiles.size() == 1) {
                 File sourceFile = matchingFiles.get(0);
-                String s3Key = normalizePath(Paths.get(s3InbucketPath, sourceFile.toPath().getFileName().toString()));
+                String s3Key = normalizePath(Paths.get(s3InbucketPath, sourceFile.toPath().toString()));
                 PutObjectRequest request = new PutObjectRequest(s3bucket, s3Key, new File(Paths.get(workingDir, sourceFile.toString()).toString()));
                 ObjectMetadata metadata = new ObjectMetadata();
                 request.setMetadata(metadata);

--- a/tasks
+++ b/tasks
@@ -125,7 +125,7 @@ case "${command}" in
     ;;
   prepare_release)
     next_version=$(releaser::get_last_version_from_changelog "${changelog_file}")
-    releaser::set_version_in_changelog "${changelog_file}" "${next_version}" "false"
+    releaser::set_version_in_changelog "${changelog_file}" "${next_version}" false
     releaser::set_version_in_file "pluginVersion = " "build.gradle" "${next_version}"
     ;;
   commit)


### PR DESCRIPTION
This is a bugfix.

When we are uploading exactly one file and it has a path with subdirectories, e.g. `x/y.json` rather than `y.json` then leading directory was lost in the AWS S3 path.

### Example:
File was
```
terraform/kudu_deployment.tfplan
```
Path on AWS is  
```
 infra-kudu-base-gocd/12/production_plan/2/plan/kudu_deployment.tfplan
```
but should be
```
infra-kudu-base-gocd/12/production_plan/2/plan/terraform/kudu_deployment.tfplan
```

The tests reproduce the problem.