### PR TITLE
Modify getFilesMatchingPattern in AntDirectoryScanner to return only files

### DIFF
--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
@@ -22,14 +22,16 @@ public class AntDirectoryScanner {
             File[] files = new File(baseDir, directory).listFiles();
             if(files != null) {
                 for(File f : files) {
-                    allFiles.add(new File(directory, f.getName()));
+                    if (!f.isDirectory()) {
+                        allFiles.add(new File(directory, f.getName()));
+                    }
                 }
             }
         }
 
         for (int i = 0; i < allPaths.length; i++) {
             File file = new File(allPaths[i]);
-            if (!allFiles.contains(file)) {
+            if ((!allFiles.contains(file)) && (!file.isDirectory())) {
                 allFiles.add(new File(allPaths[i]));
             }
         }

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
@@ -66,7 +66,54 @@ public class AntDirectoryScannerTest {
                 .hasSize(1)
                 .contains(test);
     }
-
+    @Test
+    public void shouldListFilesRecursivelyInSubFolders() throws IOException {
+        File test = createFile("out/test.bin");
+        File testA = createFile("out/dir-a/test-a.bin");
+        File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
+        File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
+        File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
+        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/");
+        assertThat(files)
+                .hasSize(5)
+                .contains(test)
+                .contains(testA)
+                .contains(testB1)
+                .contains(testB2)
+                .contains(testC);
+    }
+    @Test
+    public void shouldListFilesRecursivelyInSubFoldersForGlobPattern() throws IOException {
+        File test = createFile("out/test.bin");
+        File testA = createFile("out/dir-a/test-a.bin");
+        File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
+        File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
+        File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
+        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/dir-a/**/*");
+        assertThat(files)
+                .hasSize(4)
+                .contains(testA)
+                .contains(testB1)
+                .contains(testB2)
+                .contains(testC);
+    }
+    @Test
+    public void shouldListFilesWithPatternRecursivelyInSubFoldersForGlobPattern() throws IOException {
+        File test = createFile("out/test.bin");
+        File testA = createFile("out/dir-a/test-a.bin");
+        File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
+        File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
+        File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
+        File testD = createFile("out/dir-d/test-d.txt");
+        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/**/*.bin");
+        assertThat(files)
+                .hasSize(5)
+                .contains(test)
+                .contains(testA)
+                .contains(testB1)
+                .contains(testB2)
+                .contains(testC);
+    }
 
     private File createFile(String path) throws IOException {
         Path filepath = Paths.get(workingDir.toPath().toAbsolutePath().toString(), path);


### PR DESCRIPTION
Fix issue of not being able to upload files in subfolders recursively 

Co-authored-by: Raghav Gupta <raghav.gupta@thoughtworks.com>
Co-authored-by: Krishnaswamy Subramaniam <subramk@thoughtworks.com>