### PR TITLE
Upload nested sub-directories recursively to s3 bucket and upgrade aws-s3-sdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '18.6.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     compile group: 'com.spotify', name: 'docker-client', version: '8.10.1'
-    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.531'
+    compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.319'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
     compile group: 'org.apache.ant', name: 'ant', version: '1.10.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply from: 'https://raw.githubusercontent.com/gocd/gradle-task-helpers/4d337468
 
 gocdPlugin {
     id = 'cd.go.artifact.s3'
-    pluginVersion = "2.1.3"
+    pluginVersion = "2.1.4"
     goCdVersion = '18.7.0'
     name = 'Artifact plugin for S3'
     description = 'Plugin allows to store and fetch artifacts using Amazon S3'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply from: 'https://raw.githubusercontent.com/gocd/gradle-task-helpers/4d337468
 
 gocdPlugin {
     id = 'cd.go.artifact.s3'
-    pluginVersion = "2.1.4"
+    pluginVersion = "2.1.5"
     goCdVersion = '18.7.0'
     name = 'Artifact plugin for S3'
     description = 'Plugin allows to store and fetch artifacts using Amazon S3'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply from: 'https://raw.githubusercontent.com/gocd/gradle-task-helpers/4d337468
 
 gocdPlugin {
     id = 'cd.go.artifact.s3'
-    pluginVersion = "2.1.2"
+    pluginVersion = "2.1.3"
     goCdVersion = '18.7.0'
     name = 'Artifact plugin for S3'
     description = 'Plugin allows to store and fetch artifacts using Amazon S3'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply from: 'https://raw.githubusercontent.com/gocd/gradle-task-helpers/4d337468
 
 gocdPlugin {
     id = 'cd.go.artifact.s3'
-    pluginVersion = "2.1.1"
+    pluginVersion = "2.1.2"
     goCdVersion = '18.7.0'
     name = 'Artifact plugin for S3'
     description = 'Plugin allows to store and fetch artifacts using Amazon S3'

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishArtifactExecutor.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishArtifactExecutor.java
@@ -74,7 +74,7 @@ public class PublishArtifactExecutor implements RequestExecutor {
 
             ScanResult scanResult = scanner.getFilesMatchingPattern(new File(workingDir), sourcePattern);
             List<File> matchingFiles = scanResult.getMatchingFiles();
-            if (scanResult.hasEmptyDirectories()) {
+            if (scanResult.hasDirectories() && !scanResult.hasFiles()) {
                 String emptyDirMsg = String.format("The source directory '%s' does not have any files", sourcePattern);
                 consoleLogger.error(emptyDirMsg);
                 LOG.warn(emptyDirMsg);

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
@@ -22,14 +22,16 @@ public class AntDirectoryScanner {
             File[] files = new File(baseDir, directory).listFiles();
             if(files != null) {
                 for(File f : files) {
-                    allFiles.add(new File(directory, f.getName()));
+                    if (!f.isDirectory()) {
+                        allFiles.add(new File(directory, f.getName()));
+                    }
                 }
             }
         }
 
         for (int i = 0; i < allPaths.length; i++) {
             File file = new File(allPaths[i]);
-            if (!allFiles.contains(file)) {
+            if ((!allFiles.contains(file)) && (!file.isDirectory())) {
                 allFiles.add(new File(allPaths[i]));
             }
         }

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
@@ -9,14 +9,12 @@ import java.util.List;
 public class AntDirectoryScanner {
 
     public List<File> getFilesMatchingPattern(File baseDir, String pattern) {
-        File inputFile = new File(baseDir, pattern);
-        if (inputFile.isDirectory()) {
-            pattern += pattern.charAt(pattern.length() - 1) != File.separatorChar ? File.separator : "";
-        }
+        String[] inputPatterns = pattern.trim().split(" *, *");
+        String[] parsedPatterns = getParsedPatterns(baseDir, inputPatterns);
 
         DirectoryScanner scanner = new DirectoryScanner();
         scanner.setBasedir(baseDir);
-        scanner.setIncludes(pattern.trim().split(" *, *"));
+        scanner.setIncludes(parsedPatterns);
         scanner.scan();
 
         String[] allPaths = scanner.getIncludedFiles();
@@ -33,12 +31,28 @@ public class AntDirectoryScanner {
             }
         }
 
-        for (int i = 0; i < allPaths.length; i++) {
-            File file = new File(allPaths[i]);
+        for (String allPath : allPaths) {
+            File file = new File(allPath);
             if ((!allFiles.contains(file)) && (!file.isDirectory())) {
-                allFiles.add(new File(allPaths[i]));
+                allFiles.add(new File(allPath));
             }
         }
         return allFiles;
+    }
+
+    private String[] getParsedPatterns(File baseDir, String[] inputPatterns) {
+        String[] parsedPatterns = new String[inputPatterns.length];
+        for (int i = 0; i < inputPatterns.length; i++) {
+            String inputPattern = inputPatterns[i];
+            File inputFile = new File(baseDir, inputPattern);
+            if (inputFile.isDirectory()) {
+                inputPattern += inputPattern.charAt(inputPattern.length() - 1) != File.separatorChar ? File.separator : "";
+            }
+            if (inputPattern.matches("\\w+\\/\\*$")) {
+                inputPattern = inputPattern.substring(0, inputPattern.length() - 1);
+            }
+            parsedPatterns[i] = inputPattern;
+        }
+        return parsedPatterns;
     }
 }

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
@@ -1,15 +1,19 @@
 package diogomrol.gocd.s3.artifact.plugin.model;
 
 import org.apache.tools.ant.DirectoryScanner;
+
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class AntDirectoryScanner {
 
     public List<File> getFilesMatchingPattern(File baseDir, String pattern) {
+        File inputFile = new File(baseDir, pattern);
+        if (inputFile.isDirectory()) {
+            pattern += pattern.charAt(pattern.length() - 1) != File.separatorChar ? File.separator : "";
+        }
+
         DirectoryScanner scanner = new DirectoryScanner();
         scanner.setBasedir(baseDir);
         scanner.setIncludes(pattern.trim().split(" *, *"));

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScanner.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class AntDirectoryScanner {
 
-    public List<File> getFilesMatchingPattern(File baseDir, String pattern) {
+    public ScanResult getFilesMatchingPattern(File baseDir, String pattern) {
         String[] inputPatterns = pattern.trim().split(" *, *");
         String[] parsedPatterns = getParsedPatterns(baseDir, inputPatterns);
 
@@ -37,7 +37,7 @@ public class AntDirectoryScanner {
                 allFiles.add(new File(allPath));
             }
         }
-        return allFiles;
+        return new ScanResult(directories, allFiles);
     }
 
     private String[] getParsedPatterns(File baseDir, String[] inputPatterns) {

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/ScanResult.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/ScanResult.java
@@ -1,0 +1,30 @@
+package diogomrol.gocd.s3.artifact.plugin.model;
+
+import java.io.File;
+import java.util.List;
+
+public class ScanResult {
+    private final String[] directories;
+    private final List<File> matchingFiles;
+
+    public ScanResult(String[] directories, List<File> matchingFiles) {
+        this.directories = directories;
+        this.matchingFiles = matchingFiles;
+    }
+
+    public String[] getDirectories() {
+        return directories;
+    }
+
+    public List<File> getMatchingFiles() {
+        return matchingFiles;
+    }
+
+    public boolean hasEmptyDirectories() {
+        return directories.length > 0 && matchingFiles.isEmpty();
+    }
+
+    public boolean isEmpty() {
+        return directories.length == 0 && matchingFiles.isEmpty();
+    }
+}

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/ScanResult.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/ScanResult.java
@@ -20,11 +20,15 @@ public class ScanResult {
         return matchingFiles;
     }
 
-    public boolean hasEmptyDirectories() {
-        return directories.length > 0 && matchingFiles.isEmpty();
+    public boolean hasDirectories() {
+        return directories.length > 0;
+    }
+
+    public boolean hasFiles() {
+        return !matchingFiles.isEmpty();
     }
 
     public boolean isEmpty() {
-        return directories.length == 0 && matchingFiles.isEmpty();
+        return !hasDirectories() && !hasFiles();
     }
 }

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -32,26 +31,60 @@ public class AntDirectoryScannerTest {
     @Test
     public void shouldMatchFileByName() throws IOException {
         File test = createFile("test.bin");
-        List<File> files = scanner.getFilesMatchingPattern(workingDir, "test.bin");
-        assertThat(files)
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "test.bin");
+        assertThat(scanResult.getMatchingFiles())
                 .hasSize(1)
                 .contains(test);
+        assertThat(scanResult.getDirectories())
+                .isEmpty();
+    }
+    @Test
+    public void shouldReturnEmptyIfFileNotPresent() {
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "test.bin");
+        assertThat(scanResult.getMatchingFiles())
+                .isEmpty();
+        assertThat(scanResult.getDirectories())
+                .isEmpty();
+    }
+    @Test
+    public void shouldReturnSubDirectoriesEvenIfTheyAreEmpty() {
+        createDir("out");
+        createDir("out/sub-dir-A");
+        createDir("out/sub-dir-B");
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "out");
+        assertThat(scanResult.getMatchingFiles()).
+                isEmpty();
+        String[] scannedDirs = scanResult.getDirectories();
+        assertThat(scannedDirs)
+                .hasSize(3);
+        assertThat(scannedDirs[0]).isEqualTo("out");
+        assertThat(scannedDirs[1]).isEqualTo("out/sub-dir-A");
+        assertThat(scannedDirs[2]).isEqualTo("out/sub-dir-B");
+
     }
     @Test
     public void shouldMatchFileInSubdirectory() throws IOException {
         File test = createFile("out/test.bin");
-        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out");
-        assertThat(files)
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "out");
+        assertThat(scanResult.getMatchingFiles())
                 .hasSize(1)
                 .contains(test);
+        String[] scannedDirs = scanResult.getDirectories();
+        assertThat(scannedDirs)
+                .hasSize(1);
+        assertThat(scannedDirs[0]).isEqualTo("out");
     }
     @Test
     public void shouldNotIncludeSameFileTwiceWhenMatches2Rules() throws IOException {
         File test = createFile("out/test.bin");
-        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out,out/*.bin");
-        assertThat(files)
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "out,out/*.bin");
+        assertThat(scanResult.getMatchingFiles())
                 .hasSize(1)
                 .contains(test);
+        String[] scannedDirs = scanResult.getDirectories();
+        assertThat(scannedDirs)
+                .hasSize(1);
+        assertThat(scannedDirs[0]).isEqualTo("out");
     }
     @Test
     public void shouldListFilesRecursivelyInSubFoldersForPatternWithoutTrailingSlash() throws IOException {
@@ -60,14 +93,21 @@ public class AntDirectoryScannerTest {
         File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
         File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
         File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
-        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out");
-        assertThat(files)
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "out");
+        assertThat(scanResult.getMatchingFiles())
                 .hasSize(5)
                 .contains(test)
                 .contains(testA)
                 .contains(testB1)
                 .contains(testB2)
                 .contains(testC);
+        String[] scannedDirs = scanResult.getDirectories();
+        assertThat(scannedDirs)
+                .hasSize(4);
+        assertThat(scannedDirs[0]).isEqualTo("out");
+        assertThat(scannedDirs[1]).isEqualTo("out/dir-a");
+        assertThat(scannedDirs[2]).isEqualTo("out/dir-a/dir-b");
+        assertThat(scannedDirs[3]).isEqualTo("out/dir-a/dir-b/dir-c");
     }
     @Test
     public void shouldListFilesRecursivelyInSubFolders() throws IOException {
@@ -76,14 +116,21 @@ public class AntDirectoryScannerTest {
         File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
         File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
         File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
-        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/");
-        assertThat(files)
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "out/");
+        assertThat(scanResult.getMatchingFiles())
                 .hasSize(5)
                 .contains(test)
                 .contains(testA)
                 .contains(testB1)
                 .contains(testB2)
                 .contains(testC);
+        String[] scannedDirs = scanResult.getDirectories();
+        assertThat(scannedDirs)
+                .hasSize(4);
+        assertThat(scannedDirs[0]).isEqualTo("out");
+        assertThat(scannedDirs[1]).isEqualTo("out/dir-a");
+        assertThat(scannedDirs[2]).isEqualTo("out/dir-a/dir-b");
+        assertThat(scannedDirs[3]).isEqualTo("out/dir-a/dir-b/dir-c");
     }
     @Test
     public void shouldListFilesRecursivelyInSubFoldersForGlobPattern() throws IOException {
@@ -93,13 +140,18 @@ public class AntDirectoryScannerTest {
         File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
         File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
         File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
-        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/dir-a/**/*");
-        assertThat(files)
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "out/dir-a/**/*");
+        assertThat(scanResult.getMatchingFiles())
                 .hasSize(4)
                 .contains(testA)
                 .contains(testB1)
                 .contains(testB2)
                 .contains(testC);
+        String[] scannedDirs = scanResult.getDirectories();
+        assertThat(scannedDirs)
+                .hasSize(2);
+        assertThat(scannedDirs[0]).isEqualTo("out/dir-a/dir-b");
+        assertThat(scannedDirs[1]).isEqualTo("out/dir-a/dir-b/dir-c");
     }
     @Test
     public void shouldListFilesRecursivelyInSubFoldersForWildcardByScanningTheInputAfterStrippingTheWildcard() throws IOException {
@@ -109,14 +161,21 @@ public class AntDirectoryScannerTest {
         File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
         File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
         File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
-        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/*");
-        assertThat(files)
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "out/*");
+        assertThat(scanResult.getMatchingFiles())
                 .hasSize(5)
                 .contains(test)
                 .contains(testA)
                 .contains(testB1)
                 .contains(testB2)
                 .contains(testC);
+        String[] scannedDirs = scanResult.getDirectories();
+        assertThat(scannedDirs)
+                .hasSize(4);
+        assertThat(scannedDirs[0]).isEqualTo("out");
+        assertThat(scannedDirs[1]).isEqualTo("out/dir-a");
+        assertThat(scannedDirs[2]).isEqualTo("out/dir-a/dir-b");
+        assertThat(scannedDirs[3]).isEqualTo("out/dir-a/dir-b/dir-c");
     }
     @Test
     public void shouldListFilesWithPatternRecursivelyInSubFoldersForGlobPattern() throws IOException {
@@ -126,14 +185,17 @@ public class AntDirectoryScannerTest {
         File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
         File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
         File testD = createFile("out/dir-d/test-d.txt");
-        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/**/*.bin");
-        assertThat(files)
+        ScanResult scanResult = scanner.getFilesMatchingPattern(workingDir, "out/**/*.bin");
+        assertThat(scanResult.getMatchingFiles())
                 .hasSize(5)
                 .contains(test)
                 .contains(testA)
                 .contains(testB1)
                 .contains(testB2)
                 .contains(testC);
+        String[] scannedDirs = scanResult.getDirectories();
+        assertThat(scannedDirs)
+                .isEmpty();
     }
 
     private File createFile(String path) throws IOException {
@@ -141,6 +203,11 @@ public class AntDirectoryScannerTest {
         filepath.getParent().toFile().mkdir();
         Files.write(filepath, "".getBytes());
         return new File(path);
+    }
+
+    private boolean createDir(String path) {
+        Path filepath = Paths.get(workingDir.toPath().toAbsolutePath().toString(), path);
+        return filepath.toFile().mkdir();
     }
 
 }

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
@@ -66,7 +66,54 @@ public class AntDirectoryScannerTest {
                 .hasSize(1)
                 .contains(test);
     }
-
+    @Test
+    public void shouldListFilesRecursivelyInSubFolders() throws IOException {
+        File test = createFile("out/test.bin");
+        File testA = createFile("out/dir-a/test-a.bin");
+        File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
+        File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
+        File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
+        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/");
+        assertThat(files)
+                .hasSize(5)
+                .contains(test)
+                .contains(testA)
+                .contains(testB1)
+                .contains(testB2)
+                .contains(testC);
+    }
+    @Test
+    public void shouldListFilesRecursivelyInSubFoldersForGlobPattern() throws IOException {
+        File test = createFile("out/test.bin");
+        File testA = createFile("out/dir-a/test-a.bin");
+        File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
+        File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
+        File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
+        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/dir-a/**/*");
+        assertThat(files)
+                .hasSize(4)
+                .contains(testA)
+                .contains(testB1)
+                .contains(testB2)
+                .contains(testC);
+    }
+    @Test
+    public void shouldListFilesWithPatternRecursivelyInSubFoldersForGlobPattern() throws IOException {
+        File test = createFile("out/test.bin");
+        File testA = createFile("out/dir-a/test-a.bin");
+        File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
+        File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
+        File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
+        File testD = createFile("out/dir-d/test-d.txt");
+        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/**/*.bin");
+        assertThat(files)
+                .hasSize(5)
+                .contains(test)
+                .contains(testA)
+                .contains(testB1)
+                .contains(testB2)
+                .contains(testC);
+    }
 
     private File createFile(String path) throws IOException {
         Path filepath = Paths.get(workingDir.toPath().toAbsolutePath().toString(), path);

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
@@ -1,20 +1,10 @@
 package diogomrol.gocd.s3.artifact.plugin.model;
 
 import com.amazonaws.SdkClientException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
-import diogomrol.gocd.s3.artifact.plugin.ConsoleLogger;
-import diogomrol.gocd.s3.artifact.plugin.S3ClientFactory;
-import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,11 +12,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AntDirectoryScannerTest {
@@ -100,6 +87,7 @@ public class AntDirectoryScannerTest {
     }
     @Test
     public void shouldListFilesRecursivelyInSubFoldersForGlobPattern() throws IOException {
+        File nonMatchingFile = createFile("outlet/test.bin");
         File test = createFile("out/test.bin");
         File testA = createFile("out/dir-a/test-a.bin");
         File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
@@ -108,6 +96,23 @@ public class AntDirectoryScannerTest {
         List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/dir-a/**/*");
         assertThat(files)
                 .hasSize(4)
+                .contains(testA)
+                .contains(testB1)
+                .contains(testB2)
+                .contains(testC);
+    }
+    @Test
+    public void shouldListFilesRecursivelyInSubFoldersForWildcardByScanningTheInputAfterStrippingTheWildcard() throws IOException {
+        File nonMatchingFile = createFile("outlet/test.bin");
+        File test = createFile("out/test.bin");
+        File testA = createFile("out/dir-a/test-a.bin");
+        File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
+        File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
+        File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
+        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out/*");
+        assertThat(files)
+                .hasSize(5)
+                .contains(test)
                 .contains(testA)
                 .contains(testB1)
                 .contains(testB2)

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/AntDirectoryScannerTest.java
@@ -67,6 +67,22 @@ public class AntDirectoryScannerTest {
                 .contains(test);
     }
     @Test
+    public void shouldListFilesRecursivelyInSubFoldersForPatternWithoutTrailingSlash() throws IOException {
+        File test = createFile("out/test.bin");
+        File testA = createFile("out/dir-a/test-a.bin");
+        File testB1 = createFile("out/dir-a/dir-b/test-b1.bin");
+        File testB2 = createFile("out/dir-a/dir-b/test-b2.bin");
+        File testC = createFile("out/dir-a/dir-b/dir-c/test-c.bin");
+        List<File> files = scanner.getFilesMatchingPattern(workingDir, "out");
+        assertThat(files)
+                .hasSize(5)
+                .contains(test)
+                .contains(testA)
+                .contains(testB1)
+                .contains(testB2)
+                .contains(testC);
+    }
+    @Test
     public void shouldListFilesRecursivelyInSubFolders() throws IOException {
         File test = createFile("out/test.bin");
         File testA = createFile("out/dir-a/test-a.bin");

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/ScanResultTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/ScanResultTest.java
@@ -1,0 +1,85 @@
+package diogomrol.gocd.s3.artifact.plugin.model;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScanResultTest {
+
+    @Test
+    public void shouldReturnTrueForEmptyCheckIfScanResultHasEmptyDirectoriesAndFiles() {
+        ScanResult scanResult = new ScanResult(new String[0], Collections.emptyList());
+
+        assertThat(scanResult.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyCheckIfScanResultHasDirectories() {
+        String[] directories = new String[1];
+        directories[0] = "dir";
+        ScanResult scanResult = new ScanResult(directories, Collections.emptyList());
+
+        assertThat(scanResult.isEmpty()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyCheckIfScanResultHasMatchingFiles() {
+        List<File> files = new ArrayList<>();
+        files.add(new File("tmpFile"));
+        ScanResult scanResult = new ScanResult(new String[0], files);
+
+        assertThat(scanResult.isEmpty()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyCheckIfScanResultHasDirectoriesAndMatchingFiles() {
+        String[] directories = new String[1];
+        directories[0] = "dir";
+        List<File> files = new ArrayList<>();
+        files.add(new File("tmpFile"));
+        ScanResult scanResult = new ScanResult(directories, files);
+
+        assertThat(scanResult.isEmpty()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnTrueForEmptyDirectoriesCheckIfScanResultHasDirectoriesAndNoFiles() {
+        String[] directories = new String[2];
+        directories[0] = "dir";
+        directories[1] = "dir/sub-dir-a";
+        ScanResult scanResult = new ScanResult(directories, Collections.emptyList());
+
+        assertThat(scanResult.hasEmptyDirectories()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyDirectoriesCheckIfScanResultHasNoDirectories() {
+        String[] directories = new String[0];
+        ScanResult scanResult = new ScanResult(directories, Collections.emptyList());
+
+        assertThat(scanResult.hasEmptyDirectories()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyDirectoriesCheckIfScanResultHasNoDirectoriesAndNoFiles() {
+        ScanResult scanResult = new ScanResult(new String[0], Collections.emptyList());
+
+        assertThat(scanResult.hasEmptyDirectories()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyDirectoriesCheckIfScanResultHasNoDirectoriesButHasFiles() {
+        String[] directories = new String[0];
+        List<File> files = new ArrayList<>();
+        files.add(new File("tmpFile"));
+        ScanResult scanResult = new ScanResult(directories, files);
+
+        assertThat(scanResult.hasEmptyDirectories()).isFalse();
+    }
+}

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/ScanResultTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/ScanResultTest.java
@@ -1,10 +1,10 @@
 package diogomrol.gocd.s3.artifact.plugin.model;
 
-import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -49,37 +49,47 @@ public class ScanResultTest {
     }
 
     @Test
-    public void shouldReturnTrueForEmptyDirectoriesCheckIfScanResultHasDirectoriesAndNoFiles() {
+    public void shouldReturnTrueIfThereAreDirectories() {
         String[] directories = new String[2];
         directories[0] = "dir";
         directories[1] = "dir/sub-dir-a";
-        ScanResult scanResult = new ScanResult(directories, Collections.emptyList());
+        ScanResult scanResultWithDirsAndFiles = new ScanResult(directories, Collections.singletonList(new File("fileName")));
+        ScanResult scanResultWithDirsAndWithoutFiles = new ScanResult(directories, Collections.emptyList());
 
-        assertThat(scanResult.hasEmptyDirectories()).isTrue();
+        assertThat(scanResultWithDirsAndFiles.hasDirectories()).isTrue();
+        assertThat(scanResultWithDirsAndWithoutFiles.hasDirectories()).isTrue();
     }
 
     @Test
-    public void shouldReturnFalseForEmptyDirectoriesCheckIfScanResultHasNoDirectories() {
+    public void shouldReturnFalseIfThereIsNoDirectory() {
         String[] directories = new String[0];
-        ScanResult scanResult = new ScanResult(directories, Collections.emptyList());
+        ScanResult scanResultWithoutDirsAndWithFiles = new ScanResult(directories, Collections.singletonList(new File("fileName")));
+        ScanResult scanResultWithoutDirsAndFiles = new ScanResult(directories, Collections.emptyList());
 
-        assertThat(scanResult.hasEmptyDirectories()).isFalse();
+        assertThat(scanResultWithoutDirsAndWithFiles.hasDirectories()).isFalse();
+        assertThat(scanResultWithoutDirsAndFiles.hasDirectories()).isFalse();
     }
 
     @Test
-    public void shouldReturnFalseForEmptyDirectoriesCheckIfScanResultHasNoDirectoriesAndNoFiles() {
-        ScanResult scanResult = new ScanResult(new String[0], Collections.emptyList());
+    public void shouldReturnFalseIfThereAreNoFiles() {
+        String[] directories = new String[2];
+        directories[0] = "dir";
+        ScanResult scanResultWithoutFilesAndWithDirs = new ScanResult(directories, Collections.emptyList());
+        ScanResult scanResultWithoutFilesAndDirs = new ScanResult(new String[0], Collections.emptyList());
 
-        assertThat(scanResult.hasEmptyDirectories()).isFalse();
+        assertThat(scanResultWithoutFilesAndWithDirs.hasFiles()).isFalse();
+        assertThat(scanResultWithoutFilesAndDirs.hasFiles()).isFalse();
     }
 
     @Test
-    public void shouldReturnFalseForEmptyDirectoriesCheckIfScanResultHasNoDirectoriesButHasFiles() {
+    public void shouldReturnTrueIfThereAreFiles() {
         String[] directories = new String[0];
         List<File> files = new ArrayList<>();
         files.add(new File("tmpFile"));
-        ScanResult scanResult = new ScanResult(directories, files);
+        ScanResult scanResultWithFilesAndDirs = new ScanResult(directories, files);
+        ScanResult scanResultWithFilesAndWithoutDirs = new ScanResult(new String[0], files);
 
-        assertThat(scanResult.hasEmptyDirectories()).isFalse();
+        assertThat(scanResultWithFilesAndDirs.hasFiles()).isTrue();
+        assertThat(scanResultWithFilesAndWithoutDirs.hasFiles()).isTrue();
     }
 }


### PR DESCRIPTION
The following changes are part of the PR:
1. When a directory which has several levels of inner sub-directories is given as source for the s3 upload, then only one level of files were being uploaded. This bug was reported as part of [.](https://github.com/Diogomrol/gocd-s3-artifact-plugin/issues/17) This PR fixes the issue by recursively scanning and uploading all the inner files and sub-directories. Also, if the source ends with /* - only one level of files and directories were picked for upload. This is also now made to recursively scan till the tail of the tree and upload all the inner sub-directories and files.
2. Upgrade aws-java-sdk-s3 to 1.12.319 as it accommodates metadata service endpoint version 2. (i.e. fetching token before hitting the metadata service)