### PR TITLE
[WIP] Support S3 compatible services

### DIFF
--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/S3ClientFactory.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/S3ClientFactory.java
@@ -3,6 +3,7 @@ import diogomrol.gocd.s3.artifact.plugin.model.ArtifactStoreConfig;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -22,8 +23,17 @@ public class S3ClientFactory {
     private static AmazonS3 createClient(ArtifactStoreConfig artifactStoreConfig) throws SdkClientException {
         AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard();
 
-        if (StringUtils.isNotBlank(artifactStoreConfig.getRegion())) {
+        if (StringUtils.isNotBlank(artifactStoreConfig.getEndpointURL())) {
+            s3ClientBuilder = s3ClientBuilder.withEndpointConfiguration(
+                new EndpointConfiguration(artifactStoreConfig.getEndpointURL(), artifactStoreConfig.getRegion())
+            );
+        }
+        else if (StringUtils.isNotBlank(artifactStoreConfig.getRegion())) {
             s3ClientBuilder = s3ClientBuilder.withRegion(Regions.fromName(artifactStoreConfig.getRegion()));
+        }
+
+        if (artifactStoreConfig.getPathStyleAccess()) {
+            s3ClientBuilder.withPathStyleAccessEnabled(true);
         }
 
         if (StringUtils.isNotBlank(artifactStoreConfig.getAwsaccesskey()) && StringUtils.isNotBlank(artifactStoreConfig.getAwssecretaccesskey())) {

--- a/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/ArtifactStoreConfig.java
+++ b/src/main/java/diogomrol/gocd/s3/artifact/plugin/model/ArtifactStoreConfig.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class ArtifactStoreConfig implements Validatable {
 
-    private static final ImmutableSet<String> OPTIONAL_PROPERTIES = ImmutableSet.of("Region", "AWSAccessKey", "AWSSecretAccessKey");
+    private static final ImmutableSet<String> OPTIONAL_PROPERTIES = ImmutableSet.of("Region", "AWSAccessKey", "AWSSecretAccessKey", "EndpointURL", "PathStyleAccess");
     private static final ImmutableSet<String> AWS_ACCESS_PROPERTIES = ImmutableSet.of("AWSAccessKey", "AWSSecretAccessKey");
 
     @Expose
@@ -53,6 +53,16 @@ public class ArtifactStoreConfig implements Validatable {
     @FieldMetadata(key = "AWSSecretAccessKey", required = false, secure = true)
     private String awssecretaccesskey;
 
+    @Expose
+    @SerializedName("EndpointURL")
+    @FieldMetadata(key = "EndpointURL", required = false, secure = false)
+    private String endpointurl;
+
+    @Expose
+    @SerializedName("PathStyleAccess")
+    @FieldMetadata(key = "PathStyleAccess", required = false, secure = false)
+    private Boolean pathstyleaccess;
+
 
     public ArtifactStoreConfig() {
     }
@@ -62,13 +72,35 @@ public class ArtifactStoreConfig implements Validatable {
         this.region = region;
         this.awsaccesskey = awsaccesskey;
         this.awssecretaccesskey = awssecretaccesskey;
+        this.endpointurl = null;
+        this.pathstyleaccess = false;
+    }
+
+    public ArtifactStoreConfig(String s3bucket, String region, String awsaccesskey, String awssecretaccesskey, String endpointurl) {
+        this.s3bucket = s3bucket;
+        this.region = region;
+        this.awsaccesskey = awsaccesskey;
+        this.awssecretaccesskey = awssecretaccesskey;
+        this.endpointurl = endpointurl;
+        this.pathstyleaccess = false;
+    }
+
+    public ArtifactStoreConfig(String s3bucket, String region, String awsaccesskey, String awssecretaccesskey, String endpointurl, Boolean pathstyleaccess) {
+        this.s3bucket = s3bucket;
+        this.region = region;
+        this.awsaccesskey = awsaccesskey;
+        this.awssecretaccesskey = awssecretaccesskey;
+        this.endpointurl = endpointurl;
+        this.pathstyleaccess = pathstyleaccess;
     }
 
     public String getS3bucket() {
         return s3bucket;
     }
 
-    public String getRegion () { return region; }
+    public String getRegion () { 
+        return region;
+    }
 
     public String getAwsaccesskey() {
         return awsaccesskey;
@@ -76,6 +108,14 @@ public class ArtifactStoreConfig implements Validatable {
 
     public String getAwssecretaccesskey() {
         return awssecretaccesskey;
+    }
+
+    public String getEndpointURL() {
+        return endpointurl;
+    }
+
+    public Boolean getPathStyleAccess() {
+        return pathstyleaccess;
     }
 
     @Override
@@ -88,6 +128,8 @@ public class ArtifactStoreConfig implements Validatable {
         if (s3bucket != null ? !s3bucket.equals(that.s3bucket) : that.s3bucket != null) return false;
         if (region != null ? !region.equals(that.region) : that.region != null) return false;
         if (awsaccesskey != null ? !awsaccesskey.equals(that.awsaccesskey) : that.awsaccesskey != null) return false;
+        if (endpointurl != null ? !endpointurl.equals(that.endpointurl) : that.endpointurl != null) return false;
+        if (pathstyleaccess != null ? !pathstyleaccess.equals(that.pathstyleaccess) : that.pathstyleaccess != null) return false;
         return awssecretaccesskey != null ? awssecretaccesskey.equals(that.awssecretaccesskey) : that.awssecretaccesskey == null;
     }
 
@@ -97,6 +139,8 @@ public class ArtifactStoreConfig implements Validatable {
         result = 31 * result + (region != null ? region.hashCode() : 0);
         result = 31 * result + (awsaccesskey != null ? awsaccesskey.hashCode() : 0);
         result = 31 * result + (awssecretaccesskey != null ? awssecretaccesskey.hashCode() : 0);
+        result = 31 * result + (endpointurl != null ? endpointurl.hashCode() : 0);
+        result = 31 * result + (pathstyleaccess != null ? pathstyleaccess.hashCode() : 0);
         return result;
     }
 

--- a/src/main/resources/artifact-store.template.html
+++ b/src/main/resources/artifact-store.template.html
@@ -1,43 +1,55 @@
-<div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[S3Bucket].$error.server}">S3 Bucket:<span class='asterix'>*</span></label>
-    <input ng-class="{'is-invalid-input': GOINPUTNAME[S3Bucket].$error.server}" type="text" ng-model="S3Bucket" ng-required="true"/>
-    <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[S3Bucket].$error.server}" ng-show="GOINPUTNAME[S3Bucket].$error.server">{{GOINPUTNAME[S3Bucket].$error.server}}</span>
-</div>
+<div data-plugin-style-id="s3-artifact-plugin">
+    <style>
+        [data-plugin-style-id="s3-artifact-plugin"] .form-help-content {
+            color:         #666;
+            clear:         both;
+            font-size:     0.82rem;
+            font-style:    italic;
+            margin-top:    -15px;
+            padding-left:  2px;
+            margin-bottom: 10px;
+        }
+    </style>
 
-<div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[Region].$error.server}">Region:<span class='asterix'>*</span></label>
-    <select ng-class="{'is-invalid-input': GOINPUTNAME[Region].$error.server}" ng-model="Region" ng-required="true">
-        <option value="ap-northeast-1">ap-northeast-1</option>
-        <option value="ap-northeast-2">ap-northeast-2</option>
-        <option value="ap-south-1">ap-south-1</option>
-        <option value="ap-southeast-1">ap-southeast-1</option>
-        <option value="ap-southeast-2">ap-southeast-2</option>
-        <option value="ca-central-1">ca-central-1</option>
-        <option value="cn-north-1">cn-north-1</option>
-        <option value="cn-northwest-1">cn-northwest-1</option>
-        <option value="eu-central-1">eu-central-1</option>
-        <option value="eu-north-1">eu-north-1</option>
-        <option value="eu-west-1">eu-west-1</option>
-        <option value="eu-west-2">eu-west-2</option>
-        <option value="eu-west-3">eu-west-3</option>
-        <option value="govcloud">govcloud</option>
-        <option value="sa-east-1">sa-east-1</option>
-        <option value="us-east-1">us-east-1</option>
-        <option value="us-east-2">us-east-2</option>
-        <option value="us-west-1">us-west-1</option>
-        <option value="us-west-2">us-west-2</option>
-    </select>
-    <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[Region].$error.server}" ng-show="GOINPUTNAME[Region].$error.server">{{GOINPUTNAME[Region].$error.server}}</span>
-</div>
+    <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[S3Bucket].$error.server}">S3 Bucket:<span class='asterix'>*</span></label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[S3Bucket].$error.server}" type="text" ng-model="S3Bucket" ng-required="true"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[S3Bucket].$error.server}" ng-show="GOINPUTNAME[S3Bucket].$error.server">{{GOINPUTNAME[S3Bucket].$error.server}}</span>
+    </div>
 
-<div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[AWSAccessKey].$error.server}">AWS Access Key Id:</label>
-    <input ng-class="{'is-invalid-input': GOINPUTNAME[AWSAccessKey].$error.server}" type="text" ng-model="AWSAccessKey" ng-required="false"/>
-    <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[AWSAccessKey].$error.server}" ng-show="GOINPUTNAME[AWSAccessKey].$error.server">{{GOINPUTNAME[AWSAccessKey].$error.server}}</span>
-</div>
+    <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[Region].$error.server}">Other Region:<span class='asterix' ng-show="{GOINPUTNAME[Region] == 'other'}">*</span></label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[Region].$error.server}" type="text" ng-model="Region" ng-required="{GOINPUTNAME[Region] == 'other'}" ng-disabled="{GOINPUTNAME[Region] == 'other'}"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[Region].$error.server}" ng-show="GOINPUTNAME[Region].$error.server">{{GOINPUTNAME[Region].$error.server}}</span>
+    </div>
 
-<div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[AWSSecretAccessKey].$error.server}">AWS Secret Access Key:</label>
-    <input ng-class="{'is-invalid-input': GOINPUTNAME[AWSSecretAccessKey].$error.server}" type="password" ng-model="AWSSecretAccessKey" ng-required="false"/>
-    <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[AWSSecretAccessKey].$error.server}" ng-show="GOINPUTNAME[AWSSecretAccessKey].$error.server">{{GOINPUTNAME[AWSSecretAccessKey].$error.server}}</span>
+    <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[AWSAccessKey].$error.server}">AWS Access Key Id:</label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[AWSAccessKey].$error.server}" type="text" ng-model="AWSAccessKey" ng-required="false"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[AWSAccessKey].$error.server}" ng-show="GOINPUTNAME[AWSAccessKey].$error.server">{{GOINPUTNAME[AWSAccessKey].$error.server}}</span>
+    </div>
+
+    <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[AWSSecretAccessKey].$error.server}">AWS Secret Access Key:</label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[AWSSecretAccessKey].$error.server}" type="password" ng-model="AWSSecretAccessKey" ng-required="false"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[AWSSecretAccessKey].$error.server}" ng-show="GOINPUTNAME[AWSSecretAccessKey].$error.server">{{GOINPUTNAME[AWSSecretAccessKey].$error.server}}</span>
+    </div>
+
+    <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[EndpointURL].$error.server}">Endpoint URL:</label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[EndpointURL].$error.server}" type="text" ng-model="EndpointURL" ng-required="false"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[EndpointURL].$error.server}" ng-show="GOINPUTNAME[EndpointURL].$error.server">{{GOINPUTNAME[EndpointURL].$error.server}}</span>
+        <label class="form-help-content">
+            Optionally specify the API URL for S3-compatible services such as Minio, B2, Ceph, etc. If blank, this will use the endpoint default for the selected region.
+        </label>
+    </div>
+
+    <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[PathStyleAccess].$error.server}">Use Path-style requests?</label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[PathStyleAccess].$error.server}" type="checkbox" ng-model="PathStyleAccess"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[PathStyleAccess].$error.server}" ng-show="GOINPUTNAME[PathStyleAccess].$error.server">{{GOINPUTNAME[PathStyleAccess].$error.server}}</span>
+        <label class="form-help-content">
+            Check to use <a rel="noreferrer" href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access">Path-style requests</a> when accessing your bucket.
+        </label>
+    </div>
 </div>

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/FetchArtifactExecutorTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/FetchArtifactExecutorTest.java
@@ -61,7 +61,7 @@ public class FetchArtifactExecutorTest {
         initMocks(this);
         agentWorkingDir = tmpFolder.newFolder("go-agent");
         when(s3ClientFactory.s3(any())).thenReturn(s3Client);
-        storeConfig = new ArtifactStoreConfig("testBucket", "test", "test", "test");
+        storeConfig = new ArtifactStoreConfig("testBucket", "test", "test", "test", "test");
         fetchArtifactConfig = new FetchArtifactConfig();
     }
 

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/GetArtifactStoreConfigMetadataExecutorTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/GetArtifactStoreConfigMetadataExecutorTest.java
@@ -56,6 +56,20 @@ public class GetArtifactStoreConfigMetadataExecutorTest {
                 "      \"required\": false,\n" +
                 "      \"secure\": true\n" +
                 "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"EndpointURL\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"PathStyleAccess\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
                 "  }\n" +
                 "]";
 

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishAndFetchIntegrationTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishAndFetchIntegrationTest.java
@@ -12,6 +12,8 @@ import diogomrol.gocd.s3.artifact.plugin.ConsoleLogger;
 import diogomrol.gocd.s3.artifact.plugin.IntegrationTests;
 import diogomrol.gocd.s3.artifact.plugin.S3ClientFactory;
 import diogomrol.gocd.s3.artifact.plugin.model.*;
+import diogomrol.gocd.s3.artifact.plugin.utils.Util;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,6 +52,7 @@ public class PublishAndFetchIntegrationTest {
     ArtifactStoreConfig storeConfig;
     private String bucketName;
     private File destinationWorkingDir;
+    private Boolean pathStyleAccess;
 
     @Before
     public void setUp() throws IOException, SdkClientException {
@@ -58,7 +61,8 @@ public class PublishAndFetchIntegrationTest {
         sourceWorkingDir = temporaryFolder.newFolder("go-agent-source");
         destinationWorkingDir = temporaryFolder.newFolder("go-agent-dest");
         bucketName = System.getenv("AWS_BUCKET");
-        storeConfig = new ArtifactStoreConfig(bucketName, "eu-west-1", System.getenv("AWS_ACCESS_KEY"), System.getenv("AWS_SECRET_ACCESS_KEY"));
+        pathStyleAccess = !Util.isBlank(System.getenv("AWS_S3_PATH_STYLE_ACCESS"));
+        storeConfig = new ArtifactStoreConfig(bucketName, System.getenv("AWS_DEFAULT_REGION"), System.getenv("AWS_ACCESS_KEY_ID"), System.getenv("AWS_SECRET_ACCESS_KEY"), System.getenv("AWS_S3_ENDPOINT_URL"), pathStyleAccess);
         s3Client = s3ClientFactory.s3(storeConfig);
         ObjectListing listing = s3Client.listObjects( bucketName);
         List<S3ObjectSummary> summaries = listObjects(listing);

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishArtifactExecutorIntegrationTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishArtifactExecutorIntegrationTest.java
@@ -59,6 +59,7 @@ public class PublishArtifactExecutorIntegrationTest {
 
     ArtifactStoreConfig storeConfig;
     private String bucketName;
+    private Boolean pathStyleAccess;
 
     @Before
     public void setUp() throws IOException,  SdkClientException {
@@ -68,7 +69,8 @@ public class PublishArtifactExecutorIntegrationTest {
         bucketName = System.getenv("AWS_BUCKET");
         if(Util.isBlank(bucketName))
             throw new RuntimeException("Must set AWS_BUCKET env var");
-        storeConfig = new ArtifactStoreConfig(bucketName, "eu-west-1", System.getenv("AWS_ACCESS_KEY"), System.getenv("AWS_SECRET_ACCESS_KEY"));
+        pathStyleAccess = !Util.isBlank(System.getenv("AWS_S3_PATH_STYLE_ACCESS"));
+        storeConfig = new ArtifactStoreConfig(bucketName, System.getenv("AWS_DEFAULT_REGION"), System.getenv("AWS_ACCESS_KEY_ID"), System.getenv("AWS_SECRET_ACCESS_KEY"), System.getenv("AWS_S3_ENDPOINT_URL"), pathStyleAccess);
         s3Client = s3ClientFactory.s3(storeConfig);
         ObjectListing listing = s3Client.listObjects( bucketName);
         List<S3ObjectSummary> summaries = listObjects(listing);

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishArtifactExecutorTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/PublishArtifactExecutorTest.java
@@ -82,7 +82,7 @@ public class PublishArtifactExecutorTest {
         initMocks(this);
         agentWorkingDir = tmpFolder.newFolder("go-agent");
         when(s3ClientFactory.s3(any())).thenReturn(s3Client);
-        storeConfig = new ArtifactStoreConfig("test", "test", "test", "test");
+        storeConfig = new ArtifactStoreConfig("test", "test", "test", "test", "test", false);
     }
 
     @Test

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/ValidateArtifactStoreConfigExecutorExecutorTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/executors/ValidateArtifactStoreConfigExecutorExecutorTest.java
@@ -123,6 +123,8 @@ public class ValidateArtifactStoreConfigExecutorExecutorTest {
                 .put("Region", "us-west-1")
                 .put("AWSAccessKey", "chuck-norris")
                 .put("AWSSecretAccessKey", "chuck-norris-doesnt-need-passwords")
+                .put("EndpointURL", "https://s3.us-west-1.amazonaws.com")
+                .put("PathStyleAccess", false)
                 .toString();
         when(request.requestBody()).thenReturn(requestBody);
 

--- a/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/PublishArtifactRequestTest.java
+++ b/src/test/java/diogomrol/gocd/s3/artifact/plugin/model/PublishArtifactRequestTest.java
@@ -39,7 +39,9 @@ public class PublishArtifactRequestTest {
                 "      \"S3Bucket\": \"s3-url\",\n" +
                 "      \"Region\": \"us-west-1\",\n" +
                 "      \"AWSAccessKey\": \"aws-access-key\",\n" +
-                "      \"AWSSecretAccessKey\": \"aws-secret-access-key\"\n" +
+                "      \"AWSSecretAccessKey\": \"aws-secret-access-key\",\n" +
+                "      \"EndpointURL\": \"https://s3.us-west-1.amazonaws.com\",\n" +
+                "      \"PathStyleAccess\": false\n" +
                 "    },\n" +
                 "    \"id\": \"s3-store\"\n" +
                 "  },\n" +
@@ -52,7 +54,7 @@ public class PublishArtifactRequestTest {
 
         assertThat(publishArtifactRequest.getArtifactStore().getId()).isEqualTo("s3-store");
         assertThat(publishArtifactRequest.getArtifactStore().getArtifactStoreConfig())
-                .isEqualTo(new ArtifactStoreConfig("s3-url", "us-west-1", "aws-access-key", "aws-secret-access-key"));
+                .isEqualTo(new ArtifactStoreConfig("s3-url", "us-west-1", "aws-access-key", "aws-secret-access-key", "https://s3.us-west-1.amazonaws.com", false));
 
         assertThat(publishArtifactRequest.getArtifactPlan())
                 .isEqualTo(new ArtifactPlan("installers", "s3-store", "alpine-build.json", Optional.empty()));


### PR DESCRIPTION
* Flipping the "Regions" parameter to a normal text input both prevents us from blocking users of new AWS regions, but allows users to specify non-AWS regions. So far as I can tell, this change should not affect users who have already applied this setting.
* Add the "EndpointURL" parameter to allow users to optionally specify non-AWS, S3-compatible services. This includes Ceph, B2, Minio, etc. Rclone for example supports 23 different S3-compatible services.
* Add "PathStyleAccess" parameters as most non-AWS services will require passing this option to the SDK.
* Updated tests to accomodate for configuration changes
* Updated tests to use AWS_ACCESS_KEY_ID to match boto's expectations
* Accept additional AWS_S3_ENDPOINT_URL and AWS_S3_PATH_STYLE_ACCESS environment variables to apply this new behavior.

Passes unit and integration tests against my non-AWS bucket, the above `AWS_ACCESS_KEY_ID` change may cause this to fail the standard integration tests, as well as accepting (boto-defined) `AWS_DEFAULT_REGION` instead of the hard-coded eu-west-1.

The WIP header is mainly just unease about my AngularJS changes since test cases don't cover that. I'll deploy the built version to my GoCD instance and flip this out of WIP mode if all is well!